### PR TITLE
Add resources about Mach-O file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Created by the [DEVSE discord server](https://discord.com/invite/3XjkM6q).
 - [INTRODUCTION TO ARM ASSEMBLY BASICS](https://azeria-labs.com/writing-arm-assembly-part-1/)
 - [Wikipedia - Executable and Linkable Format](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format)
 - [Parsing Mach-O file](https://lowlevelbits.org/parsing-mach-o-files/)
+- [OS X ABI Mach-O File Format Reference](https://github.com/aidansteele/osx-abi-macho-file-format-reference)
 - [Linux insides](https://github.com/0xAX/linux-insides)
 
 ## Wikis
@@ -55,9 +56,7 @@ Created by the [DEVSE discord server](https://discord.com/invite/3XjkM6q).
 ## Design
 
 - [Operating systems : design and implementation](https://archive.org/details/OperatingSystemsDesignImplementation/mode/2up)
-- [Practical
-File System
-Design](https://web.archive.org/web/20170213221835/http://www.nobius.org/~dbg/practical-file-system-design.pdf)
+- [Practical File System Design](https://web.archive.org/web/20170213221835/http://www.nobius.org/~dbg/practical-file-system-design.pdf)
 - [linux-insides](https://0xax.gitbooks.io/linux-insides/content/index.html)
 - [Communication in Microkernel-Based Operating Systems](https://os.inf.tu-dresden.de/papers_ps/aigner_phd.pdf)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Created by the [DEVSE discord server](https://discord.com/invite/3XjkM6q).
 - [x86 and amd64 instruction reference](https://www.felixcloutier.com/x86/)
 - [INTRODUCTION TO ARM ASSEMBLY BASICS](https://azeria-labs.com/writing-arm-assembly-part-1/)
 - [Wikipedia - Executable and Linkable Format](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format)
+- [Parsing Mach-O file](https://lowlevelbits.org/parsing-mach-o-files/)
 - [Linux insides](https://github.com/0xAX/linux-insides)
 
 ## Wikis


### PR DESCRIPTION
```
Mach-O, short for Mach object file format, is a file format for executables, object code, shared libraries, dynamically-loaded code, and core dumps. A replacement for the a.out format, Mach-O offers more extensibility and faster access to information in the symbol table.

Mach-O is used by most systems based on the Mach kernel. NeXTSTEP, macOS, and iOS are examples of systems that use this format for native executables, libraries and object code. 
```
 -- Wikipedia